### PR TITLE
Fix for RGB/RGBA Colors using new notation and documentation (fixes issue #476)

### DIFF
--- a/test/test.unit.js
+++ b/test/test.unit.js
@@ -7,7 +7,7 @@
 describe('Unit testing', function () {
   'use strict';
 
-  var $compile, scope, sandbox, ChartJs, ChartJsProvider, ChartJSFactory;
+  var $compile, scope, sandbox, ChartJs, ChartJsProvider;
 
   beforeEach(module('chart.js', function (_ChartJsProvider_) {
     ChartJsProvider = _ChartJsProvider_;
@@ -103,15 +103,15 @@ describe('Unit testing', function () {
         var markup = '<canvas class="chart chart-pie" chart-data="data" chart-labels="labels" chart-colors="colors"></canvas>';
           scope.colors = [
             {
-              backgroundColor: "rgba(159,204,0,0.2)",
-              pointBackgroundColor: "rgba(159,204,0,1)",
-              pointHoverBackgroundColor: "rgba(159,204,0,0.8)",
-              borderColor: "rgba(159,204,0,1)",
+              backgroundColor: 'rgba(159,204,0,0.2)',
+              pointBackgroundColor: 'rgba(159,204,0,1)',
+              pointHoverBackgroundColor: 'rgba(159,204,0,0.8)',
+              borderColor: 'rgba(159,204,0,1)',
               pointBorderColor: '#fff',
-              pointHoverBorderColor: "rgba(159,204,0,1)"
-            },[250,109,33,0.5],"#9a9a9a",[233,177,69]
+              pointHoverBorderColor: 'rgba(159,204,0,1)'
+            },[250,109,33,0.5],'#9a9a9a',[233,177,69]
           ];
-          scope.labels = ["Green", "Peach", "Grey", "Orange"];
+          scope.labels = ['Green', 'Peach', 'Grey', 'Orange'];
           scope.data = [300, 500, 100, 150];
         scope.$on('chart-create', function (evt, chart) {         
           datasets = chart.chart.config.data.datasets;
@@ -121,10 +121,10 @@ describe('Unit testing', function () {
         console.log(datasets[0]);
         //Issue: Hex colors are converted into RGBA colors appropriately, and objects pass through fine, but RGB
         //and RGBA colors are converted into 'undefined'.
-        expect(datasets[0].backgroundColor[0]).to.equal("rgba(159,204,0,1)");
-        expect(datasets[0].backgroundColor[1]).to.equal("rgba(250,109,33,0.5");
-        expect(datasets[0].backgroundColor[2]).to.equal("rgba(154,154,154,1");
-        expect(datasets[0].backgroundColor[3]).to.equal("rgba(233,177,69,1");
+        expect(datasets[0].backgroundColor[0]).to.equal('rgba(159,204,0,1)');
+        expect(datasets[0].backgroundColor[1]).to.equal('rgba(250,109,33,0.5)');
+        expect(datasets[0].backgroundColor[2]).to.equal('rgba(154,154,154,1)');
+        expect(datasets[0].backgroundColor[3]).to.equal('rgba(233,177,69,1)');
       });
     });
 


### PR DESCRIPTION
#### Description of change

Fixes issue [#476 RGBA notation doesn't work for colouring pie chart](https://github.com/jtblin/angular-chart.js/issues/476)

Adds a new notation for RGB/RGBA colors, and new documentation for how to input RGB/RGBA colors for a chart.

Added getRGBAColor function to ChartJSFactory, added new if statements to convertColor in ChartJSFactory so that RGB colors, RGBA colors, and colors input as objects would be properly applied to charts. Wrote an appropriate test to check for each type of color input format in test.unit.js. Updated documentation regarding colors in README.md. Input for colors is different from standard RGBA/RGB Colors notation.

Note: When running 'gulp check' all tests pass, but no integrations pass. Unsure why. The fix works on projects I'm running on my local machine, and apparently for test.unit.js. Also: files in the 'dist' folder remain unchanged. I have only changed 'angular-chart.js' in the main project folder.
#### Pull Request check-list

[y] Run gulp test to ensure there are no linting, or style issues and all tests pass.
[y] Squash your commits into a few commits only.
[y] Make sure the commit message is short, concise and descriptive of the issues you're fixing.
[y] Avoid mixing up multiple issues and/or features, open one pull request for each issue.
[y] Have you updated the documentation and / or examples?
[y] Have you included a new test?
